### PR TITLE
fix(loneseed): 1.06 - removed maxrregcount parameter 

### DIFF
--- a/images/makeproject/project/apps/loneseed/1.06/windows_x86_64__cuda/loneliest-cuda_1.06.exe
+++ b/images/makeproject/project/apps/loneseed/1.06/windows_x86_64__cuda/loneliest-cuda_1.06.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea22f3ff4cea2c7d230c0137edcac02b9e6aa0b8340121037edb0338c8026e54
+size 39067136

--- a/images/makeproject/project/apps/loneseed/1.06/windows_x86_64__cuda/version.xml
+++ b/images/makeproject/project/apps/loneseed/1.06/windows_x86_64__cuda/version.xml
@@ -1,0 +1,6 @@
+<version>
+  <file>
+    <physical_name>loneliest-cuda_1.06.exe</physical_name>
+    <main_program/>
+  </file>
+</version>

--- a/images/makeproject/project/apps/loneseed/1.06/x86_64-pc-linux-gnu__cuda/loneliest-cuda_1.06.bin
+++ b/images/makeproject/project/apps/loneseed/1.06/x86_64-pc-linux-gnu__cuda/loneliest-cuda_1.06.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce6e834cdf6159722bc3ad8a0d6fca524da33d638b8cd919e283766b3bea27df
+size 38791192

--- a/images/makeproject/project/apps/loneseed/1.06/x86_64-pc-linux-gnu__cuda/version.xml
+++ b/images/makeproject/project/apps/loneseed/1.06/x86_64-pc-linux-gnu__cuda/version.xml
@@ -1,0 +1,6 @@
+<version>
+  <file>
+    <physical_name>loneliest-cuda_1.06.bin</physical_name>
+    <main_program/>
+  </file>
+</version>


### PR DESCRIPTION
from compiler as it caused inconsistent issues with various GPU models